### PR TITLE
Option to auto-show the popup menu directly

### DIFF
--- a/background/storage.js
+++ b/background/storage.js
@@ -29,6 +29,7 @@ var Storage = new function (){
         open_new_tab_last: false,
         disable_effects: false,
         auto_popup_relative_to_mouse: false,
+        auto_popup_show_menu_directly: false,
         activator_combo: [],
         show_tooltips: false,
         circular_menu: false,

--- a/options/options.html
+++ b/options/options.html
@@ -120,7 +120,12 @@ Previously opened tabs must be reloaded to show the new engines.</p>
 </div>
 
 <div class="activator_options" id="activator_auto">
-	<p>A small button will appear when some text is selected and <br />you can open the menu by moving the mouse over the button.<p>
+    <p>
+    <input type="checkbox" id="auto_popup_show_menu_directly" /> <label for="auto_popup_show_menu_directly">Show the menu directly when selecting text.</label>
+    </p>
+    <p>By default, a small button will appear when some text is selected,
+     and you can open the menu by moving the mouse over the button. Selecting
+     the above option skips showing this button and shows the menu directly.</p>
     <p>
     <input type="checkbox" id="auto_popup_relative_to_mouse" /> <label for="auto_popup_relative_to_mouse">Position the button relative to the mouse cursor.</label>
     </p>

--- a/options/options.js
+++ b/options/options.js
@@ -261,6 +261,7 @@ $(document).ready(function(){
 		$("#opt-open-new-tab-last").attr('checked', response.options.open_new_tab_last);
 
 		$("#auto_popup_relative_to_mouse").attr('checked', response.options.auto_popup_relative_to_mouse);
+		$("#auto_popup_show_menu_directly").attr('checked', response.options.auto_popup_show_menu_directly);
 
 		$("#opt-sync-engines").attr('checked', response.sync_options.sync_engines);
 		$("#opt-sync-settings").attr('checked', response.sync_options.sync_settings);
@@ -460,6 +461,7 @@ $(document).ready(function(){
 			disable_effects: $('#opt-disable-effects').is(':checked'),
 			show_tooltips: $('#opt-show-tooltips').is(':checked'),
 			auto_popup_relative_to_mouse: $('#auto_popup_relative_to_mouse').is(':checked'),
+			auto_popup_show_menu_directly: $('#auto_popup_show_menu_directly').is(':checked'),
             activator_combo: act_combo,
 			circular_menu: $('#circular_menu').is(':checked'),
 		});

--- a/popup/activators.js
+++ b/popup/activators.js
@@ -286,19 +286,26 @@ function AutoActivator(_popup, _button, _options){
 
             var x,y;
 
-            var dimensions = Positioning.enableDimensions(_button.getNode());
+            if (_options.auto_popup_show_menu_directly){
+                x = e.pageX;
+                y = e.pageY;
 
-            if (_options.auto_popup_relative_to_mouse){
-                x = e.pageX + _button.getNode().clientWidth;
-                y = e.pageY - _button.getNode().clientHeight - 10;
+                _popup.show(x, y);
             }else{
-                x = window.pageXOffset + rect.right;
-                y = window.pageYOffset + rect.top - _button.getNode().clientHeight - 10;
+                var dimensions = Positioning.enableDimensions(_button.getNode());
+
+                if (_options.auto_popup_relative_to_mouse){
+                    x = e.pageX + _button.getNode().clientWidth;
+                    y = e.pageY - _button.getNode().clientHeight - 10;
+                }else{
+                    x = window.pageXOffset + rect.right;
+                    y = window.pageYOffset + rect.top - _button.getNode().clientHeight - 10;
+                }
+
+                dimensions.restore();
+
+                _button.show(x, y);
             }
-
-            dimensions.restore();
-
-            _button.show(x, y);
 
             _lastTimer = undefined;
 


### PR DESCRIPTION
These changes add an option to the Auto activator to automatically show the popup menu directly, bypassing the showing of the popup button. This new functionality is the result of discussion in Issue #15.

I'm looking forward to your suggestions and comments about this request. :D