### PR TITLE
Disable option for button under mouse when directly showing the menu

### DIFF
--- a/options/options.css
+++ b/options/options.css
@@ -321,3 +321,19 @@ a{
 }
 
 
+.dimmable_content{
+	position:relative;
+}
+
+.dim_layer{
+	background-color: white;
+	opacity: 0.5;
+	z-index: 20;
+	height: 100%;
+	width: 100%;
+	background-repeat: no-repeat;
+	background-position: center;
+	position: absolute;
+	top: 0px;
+	left: 0px;
+}

--- a/options/options.css
+++ b/options/options.css
@@ -320,20 +320,3 @@ a{
 	display: none;
 }
 
-
-.dimmable_content{
-	position:relative;
-}
-
-.dim_layer{
-	background-color: white;
-	opacity: 0.5;
-	z-index: 20;
-	height: 100%;
-	width: 100%;
-	background-repeat: no-repeat;
-	background-position: center;
-	position: absolute;
-	top: 0px;
-	left: 0px;
-}

--- a/options/options.html
+++ b/options/options.html
@@ -126,13 +126,14 @@ Previously opened tabs must be reloaded to show the new engines.</p>
     <p>By default, a small button will appear when some text is selected,
      and you can open the menu by moving the mouse over the button. Selecting
      the above option skips showing this button and shows the menu directly.</p>
-    <div class="dimmable_content">
-        <div id="dim_layer_auto_popup_relative_to_mouse" class="dim_layer" style="display:none"></div>
-        <p>
+    <div id="auto_popup_relative_to_mouse_content">
+      <p>
         <input type="checkbox" id="auto_popup_relative_to_mouse" /> <label for="auto_popup_relative_to_mouse">Position the button relative to the mouse cursor.</label>
-        </p>
-        <p>When placed relative to the mouse cursor the button will appear to the top right of the cursor.
-         If you want to tweak the position this can be done with some custom css under "Advanced settings".</p>
+      </p>
+      <p>
+        When placed relative to the mouse cursor the button will appear to the top right of the cursor.
+        If you want to tweak the position this can be done with some custom css under "Advanced settings".
+      </p>
     </div>
 </div>
 

--- a/options/options.html
+++ b/options/options.html
@@ -126,11 +126,14 @@ Previously opened tabs must be reloaded to show the new engines.</p>
     <p>By default, a small button will appear when some text is selected,
      and you can open the menu by moving the mouse over the button. Selecting
      the above option skips showing this button and shows the menu directly.</p>
-    <p>
-    <input type="checkbox" id="auto_popup_relative_to_mouse" /> <label for="auto_popup_relative_to_mouse">Position the button relative to the mouse cursor.</label>
-    </p>
-    <p>When placed relative to the mouse cursor the button will appear to the top right of the cursor.
-     If you want to tweak the position this can be done with some custom css under "Advanced settings".</p>
+    <div class="dimmable_content">
+        <div id="dim_layer_auto_popup_relative_to_mouse" class="dim_layer" style="display:none"></div>
+        <p>
+        <input type="checkbox" id="auto_popup_relative_to_mouse" /> <label for="auto_popup_relative_to_mouse">Position the button relative to the mouse cursor.</label>
+        </p>
+        <p>When placed relative to the mouse cursor the button will appear to the top right of the cursor.
+         If you want to tweak the position this can be done with some custom css under "Advanced settings".</p>
+    </div>
 </div>
 
 

--- a/options/options.js
+++ b/options/options.js
@@ -197,20 +197,6 @@ function loadPopupPreview(){
 }
 
 
-
-	// Show the dim layer (via id) for a part of the page, which dims that
-	// part in the process.
-	function dimOn(id) {
-		document.getElementById(id).style.display = "";
-	}
-
-	// Hide the dim layer (via id) of a part of the page, which undims that
-	// part in the process.
-	function dimOff(id) {
-		document.getElementById(id).style.display = "none";
-	}
-
-
 $(document).ready(function(){
 
 
@@ -275,7 +261,7 @@ $(document).ready(function(){
 		$("#opt-open-new-tab-last").attr('checked', response.options.open_new_tab_last);
 
 		$("#auto_popup_relative_to_mouse").attr('checked', response.options.auto_popup_relative_to_mouse);
-		$("#auto_popup_show_menu_directly").attr('checked', response.options.auto_popup_show_menu_directly);
+		$("#auto_popup_show_menu_directly").attr('checked', response.options.auto_popup_show_menu_directly).change();
 
 		$("#opt-sync-engines").attr('checked', response.sync_options.sync_engines);
 		$("#opt-sync-settings").attr('checked', response.sync_options.sync_settings);
@@ -289,10 +275,6 @@ $(document).ready(function(){
             $("#combo_"+act).attr("checked", true);
 
         }
-
-        // Deactivate the option to place the button under the mouse if the
-        // option to show the menu directly is enabled.
-        $('#auto_popup_show_menu_directly').change();
 
 
         // Add search engines
@@ -569,25 +551,15 @@ $(document).ready(function(){
 	});
 
 
-	// Block and disable the relative-mouse-positioning option if the
-	// option to directly show the menu is enabled; unblock and restore the
-	// previous relative-mouse-positioning setting (for the current
-	// customizing session, if any) if the option to directly show the
-	// menu is disabled.
+	// Hide the option to position the button under the mouse if the option
+	// to directly show the menu is enabled; otherwise, show the former
+	// option.
 	$('#auto_popup_show_menu_directly').change(function(){
 
-		if($(this).is(':checked')){
-			var currentOtherValue = $('#auto_popup_relative_to_mouse').prop('checked');
-
-			$('#auto_popup_relative_to_mouse').data('oldOtherValue', currentOtherValue);
-			$('#auto_popup_relative_to_mouse').prop('checked', false);
-			dimOn("dim_layer_auto_popup_relative_to_mouse");
-		}else{
-			var oldOtherValue = $('#auto_popup_relative_to_mouse').data('oldOtherValue');
-
-			$('#auto_popup_relative_to_mouse').prop('checked', oldOtherValue);
-			dimOff("dim_layer_auto_popup_relative_to_mouse");
-		}
+		if($(this).is(':checked'))
+			$("#auto_popup_relative_to_mouse_content").hide(100);
+		else
+			$("#auto_popup_relative_to_mouse_content").show(100);
 
 	});
 

--- a/options/options.js
+++ b/options/options.js
@@ -197,6 +197,20 @@ function loadPopupPreview(){
 }
 
 
+
+	// Show the dim layer (via id) for a part of the page, which dims that
+	// part in the process.
+	function dimOn(id) {
+		document.getElementById(id).style.display = "";
+	}
+
+	// Hide the dim layer (via id) of a part of the page, which undims that
+	// part in the process.
+	function dimOff(id) {
+		document.getElementById(id).style.display = "none";
+	}
+
+
 $(document).ready(function(){
 
 
@@ -275,6 +289,10 @@ $(document).ready(function(){
             $("#combo_"+act).attr("checked", true);
 
         }
+
+        // Deactivate the option to place the button under the mouse if the
+        // option to show the menu directly is enabled.
+        $('#auto_popup_show_menu_directly').change();
 
 
         // Add search engines
@@ -547,6 +565,29 @@ $(document).ready(function(){
 
 		$('.activator_options').hide(100);
 		$('#activator_' + opt.attr('value')).show(100);
+
+	});
+
+
+	// Block and disable the relative-mouse-positioning option if the
+	// option to directly show the menu is enabled; unblock and restore the
+	// previous relative-mouse-positioning setting (for the current
+	// customizing session, if any) if the option to directly show the
+	// menu is disabled.
+	$('#auto_popup_show_menu_directly').change(function(){
+
+		if($(this).is(':checked')){
+			var currentOtherValue = $('#auto_popup_relative_to_mouse').prop('checked');
+
+			$('#auto_popup_relative_to_mouse').data('oldOtherValue', currentOtherValue);
+			$('#auto_popup_relative_to_mouse').prop('checked', false);
+			dimOn("dim_layer_auto_popup_relative_to_mouse");
+		}else{
+			var oldOtherValue = $('#auto_popup_relative_to_mouse').data('oldOtherValue');
+
+			$('#auto_popup_relative_to_mouse').prop('checked', oldOtherValue);
+			dimOff("dim_layer_auto_popup_relative_to_mouse");
+		}
 
 	});
 


### PR DESCRIPTION
Disable (by dimming) the option "Position the button relative to the mouse cursor" (in Options) whenever "Show the menu directly when selecting text" is selected. This is the result of discussion in Issue #15 and Pull Request #19.