### PR TITLE
Custom repositioning of popup at edge

### DIFF
--- a/old/engine-editor.js
+++ b/old/engine-editor.js
@@ -75,7 +75,7 @@ function EngineEditor(_shadowDOM){
 		// var pos = Common.calculateWindowPosition(_editorContainer, x, y);
 
 		_editorContainer.css({'top' : y+'px', 'left' : x+'px'});
-        Positioning.checkPosition(_editorContainer[0]);
+        Positioning.checkPosition(_editorContainer[0], null);
 
 		_saveButton.attr('disabled', true);
 		_loading.show();

--- a/options/options.html
+++ b/options/options.html
@@ -169,7 +169,7 @@ Previously opened tabs must be reloaded to show the new engines.</p>
 
 	<div id="popup-advanced-options">
 
-	<h4 class="subsection-heading">Styling</h4>
+	<h4 class="subsection-heading" id="head-styling">Styling</h4>
 
     <p id="select_theme_container"><select id="select_theme"></select> <input type="button" id="show_customize" value="Customize" /> &nbsp;&nbsp;<input type="checkbox" id="circular_menu"> <label for="circular_menu">Use circular menu (Experimental)</label></p>
 
@@ -186,7 +186,26 @@ Previously opened tabs must be reloaded to show the new engines.</p>
 	<div id="customize">
 		<div class="clearb"></div>
 
-		<p class="info" id="style-info">Here you can customize the look of the menu with <a href="http://www.w3schools.com/css/default.asp">Cascading Style Sheets</a>.</p>
+		<p class="info" id="style-info">Here you can customize the look of the menu with <a href="http://www.w3schools.com/css/default.asp">Cascading Style Sheets</a>.
+		<br><br><b>Selection Search</b> also has its own CSS-like properties that you can customize
+		in the "CONFIG_START" section after your CSS.
+                
+		<span style="padding-top: 12px; padding-left: 50px; display:block"><strong>submenu_corner, submenu_position:</strong><br />
+		These define where the submenu is placed at whenever it is opened from the main popup menu.
+		The property <b>submenu_position</b> defines the corner of the submenu button (of the main menu) that the submenu is placed at, and <b>submenu_corner</b> defines the exact corner of the submenu to place at <b>submenu_position.</b>
+		Valid values of these properties are "topright", "topleft", "bottomright", and "bottomleft".<br /><br />
+
+
+		<strong>menu_edge_right, menu_edge_bottom, menu_edge_left, menu_edge_top:</strong><br />
+                  
+		These define how the menu should be repositioned if it falls outside of the browser window.
+		If one of these properties has a value of "auto", then the menu is automatically repositioned to fit inside the window and to be flush with the window edge that it crossed.
+		If one of these properties has an integer value such as "10px", then the menu is moved that amount in pixels in the corresponding direction, without any automatic positioning done beforehand.
+		This makes it possible to prevent the menu from covering the selection whenever the selection is next to one of the window's edges.<br /><br />
+		<strong>button_edge_right, button_edge_bottom, button_edge_left, button_edge_top:</strong><br />
+		These define how the auto button (when using the Auto activator) is repositioned if it falls outside of the browser window.
+		The possible values are the same as in the above <b>menu_edge_*</b> properties, and their effect is similar.</span><br />
+		See the CSS for the "Icons only" styling preset for an example "CONFIG_START" configuration.</p>
 
 		<pre id="html">
     &lt;ul class="popup mainmenu"&gt;

--- a/options/options.html
+++ b/options/options.html
@@ -186,26 +186,28 @@ Previously opened tabs must be reloaded to show the new engines.</p>
 	<div id="customize">
 		<div class="clearb"></div>
 
-		<p class="info" id="style-info">Here you can customize the look of the menu with <a href="http://www.w3schools.com/css/default.asp">Cascading Style Sheets</a>.
-		<br><br><b>Selection Search</b> also has its own CSS-like properties that you can customize
-		in the "CONFIG_START" section after your CSS.
-                
+		<p class="info" id="style-info">Here you can customize the look of the menu with <a href="http://www.w3schools.com/css/default.asp">Cascading Style Sheets</a>.<br /><br />
+
+		You can also use special properties (unique to Selection Search) that change the way your menu or auto-button behaves.
+		These special properties are to be added to your CSS data as comments in between the keywords "CONFIG_START" and "CONFIG_END".
+		(See the CSS of the "Icons only" styling preset for an example configuration.)<br /><br />
+
+		These special properties are as follows:
 		<span style="padding-top: 12px; padding-left: 50px; display:block"><strong>submenu_corner, submenu_position:</strong><br />
-		These define where the submenu is placed at whenever it is opened from the main popup menu.
+		Define where the submenu is placed at whenever it is opened from the main popup menu.
 		The property <b>submenu_position</b> defines the corner of the submenu button (of the main menu) that the submenu is placed at, and <b>submenu_corner</b> defines the exact corner of the submenu to place at <b>submenu_position.</b>
 		Valid values of these properties are "topright", "topleft", "bottomright", and "bottomleft".<br /><br />
 
 
 		<strong>menu_edge_right, menu_edge_bottom, menu_edge_left, menu_edge_top:</strong><br />
-                  
-		These define how the menu should be repositioned if it falls outside of the browser window.
+
+		Define how the menu should be repositioned if it falls outside of the browser window.
 		If one of these properties has a value of "auto", then the menu is automatically repositioned to fit inside the window and to be flush with the window edge that it crossed.
-		If one of these properties has an integer value such as "10px", then the menu is moved that amount in pixels in the corresponding direction, without any automatic positioning done beforehand.
+		If one of these properties has an integer value such as "10px", then the menu is moved that amount in pixels in the corresponding direction, without any automatic repositioning done beforehand.
 		This makes it possible to prevent the menu from covering the selection whenever the selection is next to one of the window's edges.<br /><br />
 		<strong>button_edge_right, button_edge_bottom, button_edge_left, button_edge_top:</strong><br />
-		These define how the auto button (when using the Auto activator) is repositioned if it falls outside of the browser window.
-		The possible values are the same as in the above <b>menu_edge_*</b> properties, and their effect is similar.</span><br />
-		See the CSS for the "Icons only" styling preset for an example "CONFIG_START" configuration.</p>
+		Define how the auto button (when using the Auto activator) is repositioned if it falls outside of the browser window.
+		The possible values are the same as in the above <b>menu_edge_*</b> properties, and their effect is similar.</span></p>
 
 		<pre id="html">
     &lt;ul class="popup mainmenu"&gt;

--- a/options/options.js
+++ b/options/options.js
@@ -180,7 +180,7 @@ function loadPopupPreview(){
         popup.setSearchEngines(response.engines.slice(0, 5));
 
 
-        var button = new Button(popup);
+        var button = new Button(popup, style);
         button.showForPreview();
         preview_button.appendChild(button.getNode());
 

--- a/options/options.js
+++ b/options/options.js
@@ -587,7 +587,15 @@ $(document).ready(function(){
 
 
 	$('#show_customize').click(function(){
+		var hidden = $("#customize").is(":hidden");
+
 		$('#customize').toggle();
+
+		if (hidden){
+			$('html, body').animate({
+				scrollTop: $("#head-styling").offset().top
+			}, 500);
+		}
 
 		return false;
 	});

--- a/popup/button.js
+++ b/popup/button.js
@@ -1,7 +1,7 @@
 
 
 
-function Button(_popup){
+function Button(_popup, style){
     
 
     var _buttonNode = _createButtonNode();
@@ -33,7 +33,7 @@ function Button(_popup){
 
         _buttonNode.style.top = y + "px";
         _buttonNode.style.left = x + "px";
-        Positioning.checkPosition(_buttonNode);
+        Positioning.checkPosition(_buttonNode, style);
         _buttonNode.style.display = "block";
         _active = true;
 

--- a/popup/init_script.js
+++ b/popup/init_script.js
@@ -98,7 +98,7 @@
     }
 
     function _createAutoActivator(popup, options, dom){
-        var button = new Button(popup);
+        var button = new Button(popup, style);
         var act = new AutoActivator(popup, button, options);
         dom.appendChild(button.getNode());
         return act;

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -69,7 +69,7 @@ function Popup(options, style){
             y = pos.y;
         }
 
-        _showPopupNode(x, y, _popupNode);
+        _showPopupNode(x, y, _popupNode, style);
         _active = true;
     }
 
@@ -431,13 +431,14 @@ function Popup(options, style){
     /*
      * Shows the popup node
      */
-    function _showPopupNode(x, y, node){
+    function _showPopupNode(x, y, node, style){
 
         node.style.left = x + "px";
         node.style.top = y + "px";
 
-        // Keep it inside the screen
-        Positioning.checkPosition(node);
+        // Keep it inside the screen, or reposition it according to custom
+        // style config settings
+        Positioning.checkPosition(node, style);
 
         node.style.display = "block";
 
@@ -454,7 +455,7 @@ function Popup(options, style){
             pos = _modifier.modifySubmenuPosition(node, a, pos.x, pos.y);
         }
 
-        _showPopupNode(pos.x, pos.y, node);
+        _showPopupNode(pos.x, pos.y, node, null);
 
     }
 

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -69,7 +69,7 @@ function Popup(options, style){
             y = pos.y;
         }
 
-        _showPopupNode(x, y, _popupNode, style);
+        _showPopupNode(x, y, _popupNode);
         _active = true;
     }
 
@@ -431,7 +431,7 @@ function Popup(options, style){
     /*
      * Shows the popup node
      */
-    function _showPopupNode(x, y, node, style){
+    function _showPopupNode(x, y, node){
 
         node.style.left = x + "px";
         node.style.top = y + "px";

--- a/popup/positioning.js
+++ b/popup/positioning.js
@@ -32,9 +32,10 @@ var Positioning = new function(){
 
     /*
      * Checks that the element is inside the browser window.
-     * If not it will move the element so that it fitts inside the browser window.
+     * If not it will move the element so that it fitts inside the browser window,
+     * or according to custom positioning settings.
      */
-    this.checkPosition = function(node){
+    this.checkPosition = function(node, style){
 
 
         var dimensions = this.enableDimensions(node);
@@ -48,21 +49,61 @@ var Positioning = new function(){
             top : window.pageYOffset,
         }
 
+        // Style config settings for how to reposition the menu and button. The
+        // "null" case is for nodes that should always be automatically repositioned
+        // such as the submenu or engine editor.
+        if(style && node.classList.contains("mainmenu")){
+            var diffConfig = {
+                right : style.getConfigValue('menu_edge_right'),
+                bottom : style.getConfigValue('menu_edge_bottom'),
+                left : style.getConfigValue('menu_edge_left'),
+                top : style.getConfigValue('menu_edge_top'),
+            }
+        }else if(style && node.classList.contains("button")){
+            var diffConfig = {
+                right : style.getConfigValue('button_edge_right'),
+                bottom : style.getConfigValue('button_edge_bottom'),
+                left : style.getConfigValue('button_edge_left'),
+                top : style.getConfigValue('button_edge_top'),
+            }
+        }else if(style === null){
+            var diffConfig = {
+                right : "auto",
+                bottom : "auto",
+                left : "auto",
+                top : "auto",
+            }
+        }
+
         // How much to repositon the menu
         var diffY = null;
         var diffX = null;
 
 
-        if (pos.bottom > bounds.bottom) // Goes outside on the bottom
-            diffY = bounds.bottom - pos.bottom;
-        else if (pos.top < bounds.top) // Goes outside on the top
-            diffY = bounds.top - pos.top;
+        if (pos.bottom > bounds.bottom) { // Goes outside on the bottom
+            if (diffConfig.bottom === "auto")
+                diffY = bounds.bottom - pos.bottom;
+            else
+                diffY = parseInt(diffConfig.bottom);
+        } else if (pos.top < bounds.top) { // Goes outside on the top
+            if (diffConfig.top === "auto")
+                diffY = bounds.top - pos.top;
+            else
+                diffY = parseInt(diffConfig.top);
+        }
         
 
-        if(pos.right > bounds.right) // Goes outside on the right
-            diffX = bounds.right - pos.right;
-        else if(pos.left < bounds.left) // Goes outside on the left.
-            diffX = bounds.left - pos.left;
+        if(pos.right > bounds.right){ // Goes outside on the right
+            if (diffConfig.right === "auto")
+                diffX = bounds.right - pos.right;
+            else
+                diffX = parseInt(diffConfig.right);
+        }else if(pos.left < bounds.left){ // Goes outside on the left.
+            if (diffConfig.left === "auto")
+                diffX = bounds.left - pos.left;
+            else
+                diffX = parseInt(diffConfig.left);
+        }
 
 
         // Reposition the menu

--- a/popup/positioning.js
+++ b/popup/positioning.js
@@ -49,61 +49,24 @@ var Positioning = new function(){
             top : window.pageYOffset,
         }
 
-        // Style config settings for how to reposition the menu and button. The
-        // "null" case is for nodes that should always be automatically repositioned
-        // such as the submenu or engine editor.
-        if(style && node.classList.contains("mainmenu")){
-            var diffConfig = {
-                right : style.getConfigValue('menu_edge_right'),
-                bottom : style.getConfigValue('menu_edge_bottom'),
-                left : style.getConfigValue('menu_edge_left'),
-                top : style.getConfigValue('menu_edge_top'),
-            }
-        }else if(style && node.classList.contains("button")){
-            var diffConfig = {
-                right : style.getConfigValue('button_edge_right'),
-                bottom : style.getConfigValue('button_edge_bottom'),
-                left : style.getConfigValue('button_edge_left'),
-                top : style.getConfigValue('button_edge_top'),
-            }
-        }else if(style === null){
-            var diffConfig = {
-                right : "auto",
-                bottom : "auto",
-                left : "auto",
-                top : "auto",
-            }
-        }
+        // Style config settings for how to reposition the menu and button
+        var diffConfig = _getDiffConfig(style, node);
 
         // How much to repositon the menu
         var diffY = null;
         var diffX = null;
 
 
-        if (pos.bottom > bounds.bottom) { // Goes outside on the bottom
-            if (diffConfig.bottom === "auto")
-                diffY = bounds.bottom - pos.bottom;
-            else
-                diffY = parseInt(diffConfig.bottom);
-        } else if (pos.top < bounds.top) { // Goes outside on the top
-            if (diffConfig.top === "auto")
-                diffY = bounds.top - pos.top;
-            else
-                diffY = parseInt(diffConfig.top);
-        }
+        if (pos.bottom > bounds.bottom) // Goes outside on the bottom
+            diffY = _calculateDiff(pos.bottom, bounds.bottom, diffConfig.bottom)
+        else if (pos.top < bounds.top) // Goes outside on the top
+            diffY = _calculateDiff(pos.top, bounds.top, diffConfig.top)
         
 
-        if(pos.right > bounds.right){ // Goes outside on the right
-            if (diffConfig.right === "auto")
-                diffX = bounds.right - pos.right;
-            else
-                diffX = parseInt(diffConfig.right);
-        }else if(pos.left < bounds.left){ // Goes outside on the left.
-            if (diffConfig.left === "auto")
-                diffX = bounds.left - pos.left;
-            else
-                diffX = parseInt(diffConfig.left);
-        }
+        if(pos.right > bounds.right) // Goes outside on the right
+            diffX = _calculateDiff(pos.right, bounds.right, diffConfig.right)
+        else if(pos.left < bounds.left) // Goes outside on the left.
+            diffX = _calculateDiff(pos.left, bounds.left, diffConfig.left)
 
 
         // Reposition the menu
@@ -167,5 +130,42 @@ var Positioning = new function(){
             }
 
         }
+    }
+
+
+
+    // Style config settings for repositioning an element. Nodes such as the
+    // submenu and engine editor are always repositioned automatically.
+    function _getDiffConfig(style, node){
+        if(node.classList.contains("mainmenu")){
+            return {
+                right : style.getConfigValue('menu_edge_right'),
+                bottom : style.getConfigValue('menu_edge_bottom'),
+                left : style.getConfigValue('menu_edge_left'),
+                top : style.getConfigValue('menu_edge_top'),
+            }
+        }else if(node.classList.contains("button")){
+            return {
+                right : style.getConfigValue('button_edge_right'),
+                bottom : style.getConfigValue('button_edge_bottom'),
+                left : style.getConfigValue('button_edge_left'),
+                top : style.getConfigValue('button_edge_top'),
+            }
+        }else{
+            return {
+                right : "auto",
+                bottom : "auto",
+                left : "auto",
+                top : "auto",
+            }
+        }
+    }
+
+
+    function _calculateDiff(posValue, boundsValue, configValue){
+        if (configValue === "auto")
+            return boundsValue - posValue;
+        else
+            return parseInt(configValue);
     }
 }

--- a/popup/style.js
+++ b/popup/style.js
@@ -2,13 +2,30 @@
 function Style(shadowDOM){
 
 
-    // Which corner of the submenu to place at which corner
-    // of the submenu-link defined by the "submenu_position"
+    // The key "submenu_corner" defines which corner of the submenu to place at
+    // which corner of the submenu-link defined by the "submenu_position"
     // config option. See icons only style for example.
+    //
+    // The keys "menu_edge_*" and "button_edge_*", where "*" is "right",
+    // "bottom", "left", or "top", designate how the button or menu should be
+    // repositioned if they fall outside of the window. If one of these keys
+    // has a value of "auto", then the corresponding element is automatically
+    // repositioned to fit inside the browser window. If one of these keys has
+    // a numeric pixel value such as "10px", then the element is moved that
+    // numerical amount in the corresponding direction, without any automatic
+    // positioning done beforehand.
     
     var _defaultStyleConfig = {
         "submenu_corner" : "topleft", 
         "submenu_position" : "topright",
+        "menu_edge_right" : "auto",
+        "menu_edge_bottom" : "auto",
+        "menu_edge_left" : "auto",
+        "menu_edge_top" : "auto",
+        "button_edge_right" : "auto",
+        "button_edge_bottom" : "auto",
+        "button_edge_left" : "auto",
+        "button_edge_top" : "auto",
     };
     var _styleConfig = {};
 
@@ -86,6 +103,54 @@ function Style(shadowDOM){
 
             _styleConfig['submenu_position'] = config['submenu_position'];
 
+        }
+
+        if(config.hasOwnProperty('menu_edge_right') &&
+            config['menu_edge_right'].match(/^ *[+-]?((\d+(\.\d*)?)|(\.\d+)) *(px)? *$/)){
+
+            _styleConfig['menu_edge_right'] = config['menu_edge_right'];
+        }
+
+        if(config.hasOwnProperty('menu_edge_bottom') &&
+            config['menu_edge_bottom'].match(/^ *[+-]?((\d+(\.\d*)?)|(\.\d+)) *(px)? *$/)){
+
+            _styleConfig['menu_edge_bottom'] = config['menu_edge_bottom'];
+        }
+
+        if(config.hasOwnProperty('menu_edge_left') &&
+            config['menu_edge_left'].match(/^ *[+-]?((\d+(\.\d*)?)|(\.\d+)) *(px)? *$/)){
+
+            _styleConfig['menu_edge_left'] = config['menu_edge_left'];
+        }
+
+        if(config.hasOwnProperty('menu_edge_top') &&
+            config['menu_edge_top'].match(/^ *[+-]?((\d+(\.\d*)?)|(\.\d+)) *(px)? *$/)){
+
+            _styleConfig['menu_edge_top'] = config['menu_edge_top'];
+        }
+
+        if(config.hasOwnProperty('button_edge_right') &&
+            config['button_edge_right'].match(/^ *[+-]?((\d+(\.\d*)?)|(\.\d+)) *(px)? *$/)){
+
+            _styleConfig['button_edge_right'] = config['button_edge_right'];
+        }
+
+        if(config.hasOwnProperty('button_edge_bottom') &&
+            config['button_edge_bottom'].match(/^ *[+-]?((\d+(\.\d*)?)|(\.\d+)) *(px)? *$/)){
+
+            _styleConfig['button_edge_bottom'] = config['button_edge_bottom'];
+        }
+
+        if(config.hasOwnProperty('button_edge_left') &&
+            config['button_edge_left'].match(/^ *[+-]?((\d+(\.\d*)?)|(\.\d+)) *(px)? *$/)){
+
+            _styleConfig['button_edge_left'] = config['button_edge_left'];
+        }
+
+        if(config.hasOwnProperty('button_edge_top') &&
+            config['button_edge_top'].match(/^ *[+-]?((\d+(\.\d*)?)|(\.\d+)) *(px)? *$/)){
+
+            _styleConfig['button_edge_top'] = config['button_edge_top'];
         }
 
     }

--- a/popup/style.js
+++ b/popup/style.js
@@ -11,8 +11,8 @@ function Style(shadowDOM){
     // repositioned if they fall outside of the window. If one of these keys
     // has a value of "auto", then the corresponding element is automatically
     // repositioned to fit inside the browser window. If one of these keys has
-    // a numeric pixel value such as "10px", then the element is moved that
-    // numerical amount in the corresponding direction, without any automatic
+    // an integer value such as "10px", then the element is moved that amount
+    // (only by pixels) in the corresponding direction, without any automatic
     // positioning done beforehand.
     
     var _defaultStyleConfig = {
@@ -105,52 +105,17 @@ function Style(shadowDOM){
 
         }
 
-        if(config.hasOwnProperty('menu_edge_right') &&
-            config['menu_edge_right'].match(/^ *[+-]?((\d+(\.\d*)?)|(\.\d+)) *(px)? *$/)){
+        var edge_properties = ['menu_edge_right', 'menu_edge_bottom',
+                               'menu_edge_left', 'menu_edge_top',
+                               'button_edge_right', 'button_edge_bottom',
+                               'button_edge_left', 'button_edge_top'];
 
-            _styleConfig['menu_edge_right'] = config['menu_edge_right'];
-        }
-
-        if(config.hasOwnProperty('menu_edge_bottom') &&
-            config['menu_edge_bottom'].match(/^ *[+-]?((\d+(\.\d*)?)|(\.\d+)) *(px)? *$/)){
-
-            _styleConfig['menu_edge_bottom'] = config['menu_edge_bottom'];
-        }
-
-        if(config.hasOwnProperty('menu_edge_left') &&
-            config['menu_edge_left'].match(/^ *[+-]?((\d+(\.\d*)?)|(\.\d+)) *(px)? *$/)){
-
-            _styleConfig['menu_edge_left'] = config['menu_edge_left'];
-        }
-
-        if(config.hasOwnProperty('menu_edge_top') &&
-            config['menu_edge_top'].match(/^ *[+-]?((\d+(\.\d*)?)|(\.\d+)) *(px)? *$/)){
-
-            _styleConfig['menu_edge_top'] = config['menu_edge_top'];
-        }
-
-        if(config.hasOwnProperty('button_edge_right') &&
-            config['button_edge_right'].match(/^ *[+-]?((\d+(\.\d*)?)|(\.\d+)) *(px)? *$/)){
-
-            _styleConfig['button_edge_right'] = config['button_edge_right'];
-        }
-
-        if(config.hasOwnProperty('button_edge_bottom') &&
-            config['button_edge_bottom'].match(/^ *[+-]?((\d+(\.\d*)?)|(\.\d+)) *(px)? *$/)){
-
-            _styleConfig['button_edge_bottom'] = config['button_edge_bottom'];
-        }
-
-        if(config.hasOwnProperty('button_edge_left') &&
-            config['button_edge_left'].match(/^ *[+-]?((\d+(\.\d*)?)|(\.\d+)) *(px)? *$/)){
-
-            _styleConfig['button_edge_left'] = config['button_edge_left'];
-        }
-
-        if(config.hasOwnProperty('button_edge_top') &&
-            config['button_edge_top'].match(/^ *[+-]?((\d+(\.\d*)?)|(\.\d+)) *(px)? *$/)){
-
-            _styleConfig['button_edge_top'] = config['button_edge_top'];
+        for(var i in edge_properties){
+            var prop = edge_properties[i];
+            if(config.hasOwnProperty(prop) &&
+               config[prop].match(/^[-+]?(0|[1-9][0-9]*) *(px)?$/)){
+                _styleConfig[prop] = config[prop];
+            }
         }
 
     }


### PR DESCRIPTION
Hi Per! I have added support for custom repositioning of the menu or button whenever they are outside of the window. This helps to prevent the menu from covering the selection, or the auto button from appearing directly under the mouse, whenever the selection is next to one of the window’s edges, as per our earlier discussion in Issue #15. My solution looks a little messy in "positioning.js" with nested "if" statements, so I would be very eager to make these changes cleaner if possible.

I chose to add these features as style config options in order to keep the number of main options in "options.js" at a minimum. Also, I thought it would be nice to have these settings in the CSS style, since that is where custom positioning is already done by the user.

For example, to shift the menu 55 pixels down whenever it goes outside on the top, you can add ```"menu_edge_top":"55px"``` to ```/*CONFIG_START{ ... }CONFIG_END*/```. If you want the current behavior of automatically repositioning to fit inside the window, then you can use ```"menu_edge_top":"auto"```. When set to a numerical value such as "55px", the element is shifted without any automatic repositioning done beforehand.

As an example, I can add the following to the "Icons only" styling preset to reposition the menu so that it does not cover the selection whenever the selection is near the top of the window:
```
.mainmenu {
  margin-top: -8px;
  margin-left: -45px;
}
/*CONFIG_START{"submenu_position":"topright",
               "submenu_corner":"bottomleft",
               "menu_edge_right":"auto",
               "menu_edge_bottom":"auto",
               "menu_edge_left":"auto",
               "menu_edge_top":"55px"}CONFIG_END*/
```
Here is what this looks like:

![selection search custom repositioning 1 nov 07 2015](https://cloud.githubusercontent.com/assets/8800015/11014161/a119c2bc-84f0-11e5-93d1-7986d603c2d3.gif)

I can also also reposition the auto button so that it does not appear under the mouse whenever the selection is near the bottom of the window:
```
.mainmenu > li:first-child{
 display: none;
}
.button{
  margin-top: 36px;
  margin-left: -24px;
}
.mainmenu {
  margin-top: -8px;
  margin-left: -45px;
}
/*CONFIG_START{"submenu_position":"topright",
               "submenu_corner":"bottomleft",
               "button_edge_right":"auto",
               "button_edge_bottom":"-38px",
               "button_edge_left":"auto",
               "button_edge_top":"auto"}CONFIG_END*/
```

And here is a demo of this:

![selection search custom repositioning 2 nov 07 2015](https://cloud.githubusercontent.com/assets/8800015/11014178/42b455f6-84f1-11e5-8cf9-f162d28509a6.gif)