### PR TITLE
Scale the icon canvas to support various density displays

### DIFF
--- a/background/iconloader.js
+++ b/background/iconloader.js
@@ -75,10 +75,14 @@ IconLoader.getDefaultIcon = function(){
     return chrome.extension.getURL('img/default_favicon.png');
 }
 
+// Factor to scale the canvas by to support various display densities
+var pixelRatio = Math.max(window.devicePixelRatio || 1, 1);
+
 IconLoader._canvas = document.createElement("canvas");
-IconLoader._canvas.width = "16";
-IconLoader._canvas.height = "16";
+IconLoader._canvas.width = 16 * pixelRatio;
+IconLoader._canvas.height = 16 * pixelRatio;
 IconLoader._context = IconLoader._canvas.getContext("2d");
+IconLoader._context.scale(pixelRatio, pixelRatio);
 
 
 function IconCollection(){


### PR DESCRIPTION
Building off the research in #37, here are my changes to support a high-quality rendering of search engine icons for both traditional- and high-pixel-density displays. This change uses the current base canvas size of 16x16 to scale upward if on a high-density display (one with a devicePixelRatio of greater than 1). This allows, for example, for icons of size 32x32 or larger to be rendered with high quality on a display that has a devicePixelRatio of 2.

This change should be backwards compatible with users' current icon settings. I tested this on two devices: one Apple laptop with a high-density display (devicePixelRatio = 2) and another Apple laptop with a lower-density display (devicePixelRatio = 1). I noticed no difference in the rendering quality on the lower-density display for both icons of size 16x16 and 32x32. So users that have traditional-density displays should not see a reduction in rendering quality.