### PR TITLE
Ensure combo keys are not active after blur

### DIFF
--- a/popup/activators.js
+++ b/popup/activators.js
@@ -397,6 +397,9 @@ function KeyAndMouseActivator(_popup, _options){
 
         });
 
+        // Ensure combo is not marked as activated on page return
+        window.addEventListener('blur', _resetkeys);
+
     }
 
     function _resetkeys(){


### PR DESCRIPTION
Here is a fix for the issue I just brought up in #39.

The only case I have found that this fix doesn't cover is for "Alt-e" (opening the hamburger menu) on Windows. We could cover this case as well by adding some special logic to the "keydown" handler to detect "Alt" plus some incorrect key, but I am not sure if it is worth it to do that for a keyboard shortcut that may not be used a whole lot.... What do you think?