### PR TITLE
Fix for OUJS

### DIFF
--- a/userscripts/betaseries.com.user.js
+++ b/userscripts/betaseries.com.user.js
@@ -4,7 +4,7 @@
 // @version      0.1
 // @description  Use search url: https://www.betaseries.com/#_selectionsearch_=%s
 // @author       Pitmairen
-// @license      GPLv3
+// @license      GPL-3.0
 // @match        https://www.betaseries.com/*
 // @homepageURL  https://chrome.google.com/webstore/detail/selection-search/gipnlpdeieaidmmeaichnddnmjmcakoe
 // @supportURL   https://github.com/Pitmairen/selection-search/issues

--- a/userscripts/gog.com.user.js
+++ b/userscripts/gog.com.user.js
@@ -4,7 +4,7 @@
 // @version      0.3
 // @description  Use search url: https://www.gog.com/#_selectionsearch_=%s
 // @author       Pitmairen
-// @license      GPLv3
+// @license      GPL-3.0
 // @match        https://www.gog.com/*
 // @homepageURL  https://chrome.google.com/webstore/detail/selection-search/gipnlpdeieaidmmeaichnddnmjmcakoe
 // @supportURL   https://github.com/Pitmairen/selection-search/issues

--- a/userscripts/woerterbuchnetz.de.user.js
+++ b/userscripts/woerterbuchnetz.de.user.js
@@ -4,7 +4,7 @@
 // @version      0.5
 // @description  Use search url: http://woerterbuchnetz.de/cgi-bin/WBNetz/wbgui_py?sigle=DWB#_selectionsearch_=%s
 // @author       Pitmairen
-// @license      GPLv3
+// @license      GPL-3.0
 // @match        http://woerterbuchnetz.de/cgi-bin/WBNetz/wbgui_py*
 // @homepageURL  https://chrome.google.com/webstore/detail/selection-search/gipnlpdeieaidmmeaichnddnmjmcakoe
 // @supportURL   https://github.com/Pitmairen/selection-search/issues


### PR DESCRIPTION
OUJS has made a change recently to require SPDX codes for OSI approved licensing.

In order to improve the appearance of your script homepages it would be appreciated if you could modify all of your affected scripts. These should be the fixes for the ones you currently have on OUJS.

Until these changes are made you will be unable to update those affected scripts.

Thanks,
OUJS Staff