### PR TITLE
Dismiss popup on document scroll

### DIFF
--- a/popup/activators.js
+++ b/popup/activators.js
@@ -90,6 +90,11 @@ function ClickActivator(_popup, _options){
 
         _this.preventClickOnLinks();
 
+        document.addEventListener("scroll", function (e) {
+            if(!_this.isInCombo() && _popup.isActive()){
+                _popup.hide();
+            }
+        });
 
         document.addEventListener("mousedown", function(e){
 
@@ -210,6 +215,12 @@ function AutoActivator(_popup, _button, _options){
     var _this = this;
 
     this.setup = function(){
+
+        document.addEventListener("scroll", function (e) {
+            if(!_this.isInCombo() && _popup.isActive()){
+                _popup.hide();
+            }
+        });
 
         document.addEventListener('mousedown', function(e){
 
@@ -360,6 +371,11 @@ function KeyAndMouseActivator(_popup, _options){
                 _keys[e.which] = false;
         });
 
+        document.addEventListener("scroll", function (e) {
+            if(!_this.isInCombo() && _popup.isActive()){
+                _popup.hide();
+            }
+        });
 
         document.addEventListener('mousedown', function(e){
 
@@ -411,6 +427,12 @@ function ComboActivator(_popup, _activators){
 
 
     this.setup = function(){
+
+        document.addEventListener("scroll", function (e) {
+            if(_popup.isActive()){
+                _popup.hide();
+            }
+        });
 
         document.addEventListener('mousedown', function(e){
 


### PR DESCRIPTION
Completes #65.

Let me know if you think this is a controversial enough change to warrant exposing an option to the user. As is, we currently close the popup when a mouse click is made in the document without an option to change this behavior, and I can’t really see much value in providing such an option for the scroll event.