### PR TITLE
Page qs var no encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ and
 
 ## Changelog
 
-*0.8.63.1*
+*0.8.64*
 
-- Added option for PAGE_QS_VAR_NO_ENCODING
+- Added search-url variable PAGE_QS_VAR_NO_ENCODING to add query string variables without encoding (
+  e.g., session keys)
 
 *0.8.63*
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ and
 
 ## Changelog
 
+*0.8.63.1*
+
+- Added option for PAGE_QS_VAR_NO_ENCODING
+
 *0.8.63*
 
 - Added new buttons to allow adding new search engines/separators/submenus at specific positions in the search engine list

--- a/background/actionutils.js
+++ b/background/actionutils.js
@@ -41,7 +41,8 @@ function ContextMenuActionUtils(info, tab){
             url = url.replace(_urlVariables[i][0], _urlVariables[i][1]);
         }
 
-        if(info.pageUrl && url.match(/%PAGE_QS_VAR\(.+?\)/)){
+        if (info.pageUrl && (url.match(/%PAGE_QS_VAR\(.+?\)/) || url.match(
+            /%PAGE_QS_VAR_NO_ENCODING\(.+?\)/))) {
             url = _this.replaceQueryStringVars(url, _urlParts.query);
         }
 

--- a/background/init.js
+++ b/background/init.js
@@ -144,7 +144,7 @@ function initBackground(_previousVersion){
 
 (function(){
 
-    let CURRENT_VERSION = '0.8.63';
+    let CURRENT_VERSION = '0.8.64';
 
     storageLocalSyncInit(Storage).then(values => {
 

--- a/browseraction/actionutils.js
+++ b/browseraction/actionutils.js
@@ -28,7 +28,8 @@ function ToolbarMenuActionUtils(){
             url = url.replace(_urlVariables[i][0], _urlVariables[i][1]);
         }
 
-        if(_url !== undefined && url.match(/%PAGE_QS_VAR\(.+?\)/)){
+        if (_url !== undefined && (url.match(/%PAGE_QS_VAR\(.+?\)/)
+            || url.match(/%PAGE_QS_VAR_NO_ENCODING\(.+?\)/))) {
             url = _this.replaceQueryStringVars(url, _urlParts.query);
         }
 

--- a/common/actionutils.js
+++ b/common/actionutils.js
@@ -231,28 +231,39 @@ function BaseActionUtils(){
     this.replaceQueryStringVars = function(url, qs){
 
 		var qs_map = {}
-		if(qs.length !== 0){
+        if (qs.length !== 0) {
             var qs_parts = qs.split('&');
-            for(var i in qs_parts){
-				var qs_var = qs_parts[i].split('=');
-				if (qs_var.length == 2){
-					qs_map[qs_var[0]] = qs_var[1];
-				}
-		    }
+            for (var i in qs_parts) {
+                var qs_var = qs_parts[i].split('=');
+                if (qs_var.length == 2) {
+                    qs_map[qs_var[0]] = qs_var[1];
+                }
+            }
         }
 
-		url = url.replace(/%PAGE_QS_VAR\((.+?)\)/g, function(m, qs_key){
-			if (qs_key in qs_map){
-				if(qs_map[qs_key].substr(0, 11) === 'javascript:')
-					return '';
-				return encodeURIComponent(qs_map[qs_key]);
-			}
-			return '';
-		});
+        url = url.replace(/%PAGE_QS_VAR_NO_ENCODING\((.+?)\)/g,
+            function (m, qs_key) {
+                if (qs_key in qs_map) {
+                    if (qs_map[qs_key].substr(0, 11) === 'javascript:') {
+                        return '';
+                    }
+                    return decodeURIComponent(qs_map[qs_key]);
+                }
+                return '';
+            });
 
-		return url;
-	}
+        url = url.replace(/%PAGE_QS_VAR\((.+?)\)/g, function (m, qs_key) {
+            if (qs_key in qs_map) {
+                if (qs_map[qs_key].substr(0, 11) === 'javascript:') {
+                    return '';
+                }
+                return encodeURIComponent(qs_map[qs_key]);
+            }
+            return '';
+        });
 
+        return url;
+    }
 
     this.isSubmenuWithUrl = function(engine){
         return engine.is_submenu && engine.url && engine.url !== 'Submenu';

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "Selection Search",
-    "version": "0.8.63",
+    "version": "0.8.64",
     "manifest_version": 2,
     "description": "Search for the selected text in search engines",
     "minimum_chrome_version": "35",

--- a/options/options.html
+++ b/options/options.html
@@ -58,6 +58,11 @@ http://example.com/search/<strong>{POSTARGS}</strong>q=<strong>%s</strong>&amp;t
 
 	<dt>%PAGE_QS_VAR(name)</dt>
 	<dd>A query string variable from the current page (%PAGE_QS_VAR(key1) == value1)</dd>
+
+	<dt>%PAGE_QS_VAR_NO_ENCODING(name)</dt>
+	<dd>A query string variable from the current page (%PAGE_QS_VAR(key1) == value1), but does not
+		encode special characters
+	</dd>
 </dl>
 
 <strong>For Icon url:</strong>

--- a/popup/actions.js
+++ b/popup/actions.js
@@ -263,7 +263,8 @@ function PopupActionUtils(){
             url = url.replace(_urlVariables[i][0], _urlVariables[i][1]);
         }
 
-        if(url.match(/%PAGE_QS_VAR\(.+?\)/)){
+        if (url.match(/%PAGE_QS_VAR\(.+?\)/) || url.match(
+            /%PAGE_QS_VAR_NO_ENCODING\(.+?\)/)) {
             url = _this.replaceQueryStringVars(url, location.search.substr(1));
         }
         return url;


### PR DESCRIPTION
Add the possibility to add query string variable without getting them encoded, such that they can be used for session keys.